### PR TITLE
Fix protocol fee query

### DIFF
--- a/fee_query.sql
+++ b/fee_query.sql
@@ -53,12 +53,12 @@ order_protocol_fee AS (
                 -- impossible anyways. This query will return a division by
                 -- zero error in that case.
                 LEAST(
-                    fp.max_volume_factor * os.sell_amount * os.buy_amount / (os.sell_amount - os.observed_fee),
+                    fp.surplus_max_volume_factor * os.sell_amount * os.buy_amount / (os.sell_amount - os.observed_fee),
                     -- at most charge a fraction of volume
                     fp.surplus_factor / (1 - fp.surplus_factor) * surplus -- charge a fraction of surplus
                 )
                 WHEN os.kind = 'buy' THEN LEAST(
-                    fp.max_volume_factor / (1 + fp.max_volume_factor) * os.sell_amount,
+                    fp.surplus_max_volume_factor / (1 + fp.surplus_max_volume_factor) * os.sell_amount,
                     -- at most charge a fraction of volume
                     fp.surplus_factor / (1 - fp.surplus_factor) * surplus -- charge a fraction of surplus
                 )


### PR DESCRIPTION
The paramter for capping surplus based protocol fees to a fraction of volume was renamed from `max_volume_factor` to `surplus_max_volume_factor` in our database. This PR changes the protocol fee query accordingly.