### PR TITLE
Update mainnet query

### DIFF
--- a/cow_amm_notebook.ipynb
+++ b/cow_amm_notebook.ipynb
@@ -65,10 +65,11 @@
    "outputs": [],
    "source": [
     "time_now = time()\n",
-    "start_time = 1708691819\n",
-    "protocol_fee_wei = 192533777180722430\n",
-    "df_cow_filtered = df_cow.filter(pl.col(\"time\") >= start_time)\n",
-    "df_balancer_filtered = df_balancer.filter(pl.col(\"time\") >= start_time)"
+    "start_time = 1712564737\n",
+    "end_time = 1713171275\n",
+    "protocol_fee_wei = 89264911874766030\n",
+    "df_cow_filtered = df_cow.filter((pl.col(\"time\") >= start_time) & (pl.col(\"time\") <= end_time))\n",
+    "df_balancer_filtered = df_balancer.filter((pl.col(\"time\") >= start_time) & (pl.col(\"time\") <= end_time))"
    ]
   },
   {
@@ -190,7 +191,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.1"
+   "version": "3.12.2"
   }
  },
  "nbformat": 4,

--- a/dataframes.py
+++ b/dataframes.py
@@ -94,7 +94,11 @@ def combine_with_prices(df_amm, df_weth_prices, df_cow_prices):
 
 def plot_profit_vs_holding(df):
     plt = (
-        df.filter(~(pl.col("total_value_change").log().abs() > 2))
+        df.filter(
+            (pl.col("WETH").diff() != 0)
+            & (pl.col("COW").diff() != 0)
+            & (pl.col("WETH").diff() * pl.col("COW").diff() < 0)
+        )
         .with_columns(
             pl.col("profit_vs_holding_change")
             .cum_prod()
@@ -115,7 +119,9 @@ def compute_profit_vs_holding_apy(df, correction=1):
     # power = 1
     profit_vs_holding = (
         df_filtered.filter(
-            ~(pl.col("profit_vs_holding_change").log().abs() > 0.01)
+            (pl.col("WETH").diff() != 0)
+            & (pl.col("COW").diff() != 0)
+            & (pl.col("WETH").diff() * pl.col("COW").diff() < 0)
         ).with_columns(
             pl.col("profit_vs_holding_change")
             .cum_prod()

--- a/dataframes.py
+++ b/dataframes.py
@@ -95,9 +95,12 @@ def combine_with_prices(df_amm, df_weth_prices, df_cow_prices):
 def plot_profit_vs_holding(df):
     plt = (
         df.filter(
-            (pl.col("WETH").diff() != 0)
-            & (pl.col("COW").diff() != 0)
-            & (pl.col("WETH").diff() * pl.col("COW").diff() < 0)
+            ((pl.col("WETH").diff() == 0) & (pl.col("COW").diff() == 0))
+            | (
+                (pl.col("WETH").diff() != 0)
+                & (pl.col("COW").diff() != 0)
+                & (pl.col("WETH").diff() * pl.col("COW").diff() < 0)
+            )
         )
         .with_columns(
             pl.col("profit_vs_holding_change")
@@ -119,9 +122,12 @@ def compute_profit_vs_holding_apy(df, correction=1):
     # power = 1
     profit_vs_holding = (
         df_filtered.filter(
-            (pl.col("WETH").diff() != 0)
-            & (pl.col("COW").diff() != 0)
-            & (pl.col("WETH").diff() * pl.col("COW").diff() < 0)
+            ((pl.col("WETH").diff() == 0) & (pl.col("COW").diff() == 0))
+            | (
+                (pl.col("WETH").diff() != 0)
+                & (pl.col("COW").diff() != 0)
+                & (pl.col("WETH").diff() * pl.col("COW").diff() < 0)
+            )
         ).with_columns(
             pl.col("profit_vs_holding_change")
             .cum_prod()

--- a/fee_query.sql
+++ b/fee_query.sql
@@ -1,26 +1,34 @@
-with order_surplus AS (
-    SELECT
-        s.block_number,
-        ss.winner as solver,
+WITH order_surplus AS (
+    SELECT ss.winner as solver,
         s.auction_id,
         s.tx_hash,
         t.order_uid,
         o.sell_token,
         o.buy_token,
-        t.sell_amount, -- the total amount the user sends
-        t.buy_amount, -- the total amount the user receives
-        oe.surplus_fee as observed_fee, -- the total discrepancy between what the user sends and what they would have send if they traded at clearing price
+        t.sell_amount,
+        -- the total amount the user sends
+        t.buy_amount,
+        -- the total amount the user receives
+        oe.surplus_fee as observed_fee,
+        -- the total discrepancy between what the user sends and what they would have send if they traded at clearing price
         o.kind,
         CASE
             WHEN o.kind = 'sell' THEN t.buy_amount - t.sell_amount * o.buy_amount / (o.sell_amount + o.fee_amount)
             WHEN o.kind = 'buy' THEN t.buy_amount * (o.sell_amount + o.fee_amount) / o.buy_amount - t.sell_amount
         END AS surplus,
         CASE
+            WHEN o.kind = 'sell' THEN t.buy_amount - t.sell_amount * (
+                oq.buy_amount - oq.buy_amount / oq.sell_amount * oq.gas_amount * oq.gas_price / oq.sell_token_price
+            ) / oq.sell_amount
+            WHEN o.kind = 'buy' THEN t.buy_amount * (
+                oq.sell_amount + oq.gas_amount * oq.gas_price / oq.sell_token_price
+            ) / oq.buy_amount - t.sell_amount
+        END AS price_improvement,
+        CASE
             WHEN o.kind = 'sell' THEN o.buy_token
             WHEN o.kind = 'buy' THEN o.sell_token
         END AS surplus_token
-    FROM
-        settlements s
+    FROM settlements s
         JOIN settlement_scores ss -- contains block_deadline
         ON s.auction_id = ss.auction_id
         JOIN trades t -- contains traded amounts
@@ -30,15 +38,16 @@ with order_surplus AS (
         JOIN order_execution oe -- contains surplus fee
         ON t.order_uid = oe.order_uid
         AND s.auction_id = oe.auction_id
+        LEFT OUTER JOIN order_quotes oq -- contains quote amounts
+        ON o.uid = oq.order_uid
     WHERE owner = '\xBEEf5aFE88eF73337e5070aB2855d37dBF5493A4'
-    and s.block_number >= 19290334
+        AND s.block_number >= 19290334
 ),
 order_protocol_fee AS (
-    SELECT
-        os.block_number,
-        os.auction_id,
+    SELECT os.auction_id,
         os.solver,
         os.tx_hash,
+        os.order_uid,
         os.sell_amount,
         os.buy_amount,
         os.sell_token,
@@ -47,13 +56,12 @@ order_protocol_fee AS (
         os.surplus_token,
         CASE
             WHEN fp.kind = 'surplus' THEN CASE
-                WHEN os.kind = 'sell' THEN
-                -- We assume that the case surplus_factor != 1 always. In
+                WHEN os.kind = 'sell' THEN -- We assume that the case surplus_factor != 1 always. In
                 -- that case reconstructing the protocol fee would be
                 -- impossible anyways. This query will return a division by
                 -- zero error in that case.
                 LEAST(
-                    fp.surplus_max_volume_factor * os.sell_amount * os.buy_amount / (os.sell_amount - os.observed_fee),
+                    fp.surplus_max_volume_factor / (1 - fp.surplus_max_volume_factor) * os.buy_amount,
                     -- at most charge a fraction of volume
                     fp.surplus_factor / (1 - fp.surplus_factor) * surplus -- charge a fraction of surplus
                 )
@@ -63,22 +71,39 @@ order_protocol_fee AS (
                     fp.surplus_factor / (1 - fp.surplus_factor) * surplus -- charge a fraction of surplus
                 )
             END
-            WHEN fp.kind = 'volume' THEN fp.volume_factor / (1 + fp.volume_factor) * os.sell_amount
+            WHEN fp.kind = 'priceimprovement' THEN CASE
+                WHEN os.kind = 'sell' THEN LEAST(
+                    -- at most charge a fraction of volume
+                    fp.price_improvement_max_volume_factor / (1 - fp.price_improvement_max_volume_factor) * os.buy_amount,
+                    -- charge a fraction of price improvement, at most 0
+                    GREATEST(
+                        fp.price_improvement_factor / (1 - fp.price_improvement_factor) * price_improvement,
+                        0
+                    )
+                )
+                WHEN os.kind = 'buy' THEN LEAST(
+                    -- at most charge a fraction of volume
+                    fp.price_improvement_max_volume_factor / (1 + fp.price_improvement_max_volume_factor) * os.sell_amount,
+                    -- charge a fraction of price improvement
+                    GREATEST(
+                        fp.price_improvement_factor / (1 - fp.price_improvement_factor) * price_improvement,
+                        0
+                    )
+                )
+            END
+            WHEN fp.kind = 'volume' THEN CASE
+                WHEN os.kind = 'sell' THEN fp.volume_factor / (1 - fp.volume_factor) * os.buy_amount
+                WHEN os.kind = 'buy' THEN fp.volume_factor / (1 + fp.volume_factor) * os.sell_amount
+            END
         END AS protocol_fee,
-        CASE
-            WHEN fp.kind = 'surplus' THEN os.surplus_token
-            WHEN fp.kind = 'volume' THEN os.sell_token
-        END AS protocol_fee_token
-    FROM
-        order_surplus os
+        os.surplus_token AS protocol_fee_token
+    FROM order_surplus os
         JOIN fee_policies fp -- contains protocol fee policy
         ON os.auction_id = fp.auction_id
         AND os.order_uid = fp.order_uid
 ),
 order_protocol_fee_prices AS (
-    SELECT
-        opf.block_number,
-        opf.solver,
+    SELECT opf.solver,
         opf.tx_hash,
         opf.surplus,
         opf.protocol_fee,
@@ -91,8 +116,7 @@ order_protocol_fee_prices AS (
         ap_surplus.price / pow(10, 18) as surplus_token_price,
         ap_protocol.price / pow(10, 18) as protocol_fee_token_price,
         ap_sell.price / pow(10, 18) as network_fee_token_price
-    FROM
-        order_protocol_fee opf
+    FROM order_protocol_fee opf
         JOIN auction_prices ap_sell -- contains price: sell token
         ON opf.auction_id = ap_sell.auction_id
         AND opf.sell_token = ap_sell.token
@@ -103,8 +127,7 @@ order_protocol_fee_prices AS (
         ON opf.auction_id = ap_protocol.auction_id
         AND opf.protocol_fee_token = ap_protocol.token
 )
-select
-    sum(surplus * surplus_token_price) / pow(10, 18) as surplus_eth,
+select sum(surplus * surplus_token_price) / pow(10, 18) as surplus_eth,
     sum(protocol_fee * protocol_fee_token_price) / pow(10, 18) as protocol_fee_eth,
     sum(network_fee * network_fee_token_price) / pow(10, 18) as network_fee_eth
 from order_protocol_fee_prices


### PR DESCRIPTION
There have been some changes to how we inject liquidity and how we compute protocol fees in the last weeks.

This PR updates the mainnet query to to the latest state.

The following changes are included:
- new time range in notebook corresponting to last week
- new parsing of transfers for cow amm to handle single sided liquidity injection
- fix filtering in profit computation
- add new protocol fee to fee query